### PR TITLE
Add interactive world map page with country details

### DIFF
--- a/foodie/app.py
+++ b/foodie/app.py
@@ -104,6 +104,10 @@ def serve_business_order():
 def serve_user_profile():
     return send_from_directory(app.static_folder, 'user_profile.html')
 
+@app.route('/world_map.html')
+def serve_world_map():
+    return send_from_directory(app.static_folder, 'world_map.html')
+
 # --- API Endpoints ---
 # These endpoints are what your JavaScript will call using fetch().
 @app.route('/api/search', methods=['POST'])

--- a/foodie/static/css/world_map.css
+++ b/foodie/static/css/world_map.css
@@ -1,0 +1,95 @@
+:root {
+    color-scheme: light;
+    font-family: "Poppins", Arial, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: #f3f6fa;
+    color: #152033;
+}
+
+.map-header {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    background: #102030;
+    color: #fff;
+    border-bottom: 4px solid #ff9f1a;
+}
+
+.map-header h1 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+.map-header p {
+    margin: 0.35rem 0 0;
+    color: #c7d4e3;
+}
+
+.back-link {
+    color: #fff;
+    text-decoration: none;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.45rem;
+    background: #1f3a56;
+}
+
+main {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    min-height: calc(100vh - 86px);
+}
+
+.panel {
+    padding: 1.2rem;
+    background: #ffffff;
+    border-right: 1px solid #dce3ec;
+}
+
+.panel h2,
+.panel h3 {
+    margin-top: 0;
+}
+
+.panel ul {
+    padding-left: 1.1rem;
+}
+
+.country-info {
+    margin-top: 1.25rem;
+    padding: 0.9rem;
+    border-radius: 0.6rem;
+    background: #f2f6fd;
+    border: 1px solid #d8e4fb;
+}
+
+.world-map {
+    width: 100%;
+    height: calc(100vh - 86px);
+}
+
+.country-popup {
+    min-width: 180px;
+}
+
+@media (max-width: 920px) {
+    main {
+        grid-template-columns: 1fr;
+    }
+
+    .panel {
+        border-right: none;
+        border-bottom: 1px solid #dce3ec;
+    }
+
+    .world-map {
+        height: 70vh;
+    }
+}

--- a/foodie/static/index.html
+++ b/foodie/static/index.html
@@ -26,6 +26,7 @@
                 <li><a href="business_order.html"><i class="fa-solid fa-briefcase"></i> Business Order</a></li>
                 <li><a href="restaurants.html"><i class="fa-solid fa-store"></i> Restaurants</a></li>
                 <li><a href="indie.html"><i class="fa-solid fa-leaf"></i> Indie</a></li>
+                <li><a href="world_map.html"><i class="fa-solid fa-earth-americas"></i> World Map</a></li>
             </ul>
 
             <div class="nav-right">

--- a/foodie/static/js/world_map.js
+++ b/foodie/static/js/world_map.js
@@ -1,0 +1,125 @@
+const map = L.map('world-map', {
+    zoomControl: true,
+    minZoom: 2,
+    maxZoom: 10,
+    worldCopyJump: true,
+}).setView([20, 0], 2);
+
+const streetLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors',
+    maxZoom: 19,
+});
+
+const terrainLayer = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors, SRTM | &copy; OpenTopoMap',
+    maxZoom: 17,
+});
+
+streetLayer.addTo(map);
+
+L.control.layers(
+    {
+        'Street (OSM)': streetLayer,
+        'Terrain (OpenTopoMap)': terrainLayer,
+    },
+    {},
+    { position: 'topright' }
+).addTo(map);
+
+const countryInfo = document.getElementById('country-info');
+let activeLayer = null;
+
+const formatNumber = (value) => {
+    if (!value || Number.isNaN(Number(value))) {
+        return 'N/A';
+    }
+    return Number(value).toLocaleString();
+};
+
+const countryStyle = {
+    color: '#314d72',
+    weight: 0.9,
+    fillColor: '#4f88d5',
+    fillOpacity: 0.25,
+};
+
+const highlightStyle = {
+    color: '#f27329',
+    weight: 2,
+    fillOpacity: 0.5,
+};
+
+function updateInfo(properties) {
+    const name = properties.ADMIN || properties.name || 'Unknown';
+    const iso = properties.ISO_A3 || properties.iso_a3 || 'N/A';
+    const pop = properties.POP_EST || properties.population || null;
+    const continent = properties.CONTINENT || properties.continent || 'N/A';
+
+    countryInfo.innerHTML = `
+        <h3>Selected Country</h3>
+        <p><strong>Name:</strong> ${name}</p>
+        <p><strong>ISO Code:</strong> ${iso}</p>
+        <p><strong>Continent:</strong> ${continent}</p>
+        <p><strong>Population (est.):</strong> ${formatNumber(pop)}</p>
+    `;
+}
+
+function onEachCountry(feature, layer) {
+    const props = feature.properties || {};
+    const name = props.ADMIN || props.name || 'Unknown';
+    const iso = props.ISO_A3 || props.iso_a3 || 'N/A';
+    const continent = props.CONTINENT || props.continent || 'N/A';
+    const pop = formatNumber(props.POP_EST || props.population || null);
+
+    layer.bindPopup(`
+        <div class="country-popup">
+            <strong>${name}</strong><br>
+            ISO: ${iso}<br>
+            Continent: ${continent}<br>
+            Population: ${pop}
+        </div>
+    `);
+
+    layer.on({
+        mouseover: (event) => {
+            event.target.setStyle(highlightStyle);
+        },
+        mouseout: (event) => {
+            if (activeLayer !== event.target) {
+                countriesLayer.resetStyle(event.target);
+            }
+        },
+        click: (event) => {
+            if (activeLayer) {
+                countriesLayer.resetStyle(activeLayer);
+            }
+            activeLayer = event.target;
+            activeLayer.setStyle(highlightStyle);
+            map.fitBounds(activeLayer.getBounds(), { padding: [25, 25], maxZoom: 5 });
+            updateInfo(props);
+        },
+    });
+}
+
+let countriesLayer;
+
+fetch('https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson')
+    .then((response) => {
+        if (!response.ok) {
+            throw new Error('Country data could not be loaded.');
+        }
+        return response.json();
+    })
+    .then((geojson) => {
+        countriesLayer = L.geoJSON(geojson, {
+            style: countryStyle,
+            onEachFeature: onEachCountry,
+        }).addTo(map);
+    })
+    .catch((error) => {
+        countryInfo.innerHTML = `
+            <h3>Selected Country</h3>
+            <p>Unable to load country boundaries right now.</p>
+            <p><small>${error.message}</small></p>
+        `;
+    });

--- a/foodie/static/world_map.html
+++ b/foodie/static/world_map.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive World Map | Foodie</title>
+    <link rel="icon" type="image/x-icon" href="img/logo.ico" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+    <link rel="stylesheet" href="css/world_map.css">
+</head>
+<body>
+    <header class="map-header">
+        <a href="/" class="back-link">← Back to Foodie</a>
+        <div>
+            <h1>Detailed Interactive World Map</h1>
+            <p>Explore countries, borders, and key national details with real map data.</p>
+        </div>
+    </header>
+
+    <main>
+        <aside class="panel" aria-label="Map Controls">
+            <h2>Map Layers</h2>
+            <p>Switch between street and terrain maps, then click a country to inspect details.</p>
+            <ul>
+                <li><strong>Pan:</strong> click and drag</li>
+                <li><strong>Zoom:</strong> mouse wheel or + / - buttons</li>
+                <li><strong>Country detail:</strong> click any country polygon</li>
+            </ul>
+            <section id="country-info" class="country-info" aria-live="polite">
+                <h3>Selected Country</h3>
+                <p>Click a country on the map to view details.</p>
+            </section>
+        </aside>
+        <section id="world-map" class="world-map" aria-label="Interactive World Map"></section>
+    </main>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="js/world_map.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide users with a detailed interactive map inside the Foodie frontend so they can explore country boundaries and basic national metadata directly from the site.
- Reuse a lightweight client-side mapping stack to avoid heavy server changes while enabling rich interactions (hover, click, layer switching).

### Description
- Added a new static page `foodie/static/world_map.html` that embeds Leaflet and a map canvas with a side info panel for selected country details.
- Implemented layout and responsive styles in `foodie/static/css/world_map.css` for header, control panel and map canvas.
- Implemented client-side behavior in `foodie/static/js/world_map.js` to load country boundaries from a public GeoJSON, provide OSM/terrain base layers, hover/click highlighting, popups and a side panel showing `Name`, `ISO Code`, `Continent`, and `Population`.
- Added a Flask static route `@app.route('/world_map.html')` in `foodie/app.py` and linked the new page from the main navigation in `foodie/static/index.html`.

### Testing
- Ran `python -m py_compile foodie/app.py` which succeeded to validate Python syntax in the modified backend file.
- Served the static files with `python -m http.server 8000` and opened `http://127.0.0.1:8000/world_map.html` to validate the page layout and interactive behavior successfully.
- Executed a Playwright script to load the page and capture a visual verification screenshot (screenshot artifact produced: `artifacts/world-map-page.png`).
- Attempted to run the full Flask app with `python foodie/app.py` but it failed in this environment due to the `flask` dependency not being installed (`ModuleNotFoundError: No module named 'flask'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ae337f3c832893b00dc2fb966443)